### PR TITLE
Make exercise reference discovery dynamic based on user request

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -60,7 +60,7 @@ export async function POST(req: Request) {
     return new Response("Failed to create generation", { status: 500 });
   }
 
-  const { messages: conversationMessages, lastCodeBlobKey, initialGuidelines } =
+  const { messages: conversationMessages, lastCodeBlobKey } =
     createConversationHistory(generations);
 
   const sandbox = await getAgentSandbox();
@@ -72,7 +72,6 @@ export async function POST(req: Request) {
     sandbox,
     generationId: lastGeneration.id,
     slug,
-    initialGuidelines,
   });
 
   const result = await agent.stream({ messages: conversationMessages });

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -60,8 +60,8 @@ export async function POST(req: Request) {
     return new Response("Failed to create generation", { status: 500 });
   }
 
-  const { messages: conversationMessages, lastCodeBlobKey } =
-    createConversationHistory(generations, slug);
+  const { messages: conversationMessages, lastCodeBlobKey, initialGuidelines } =
+    createConversationHistory(generations);
 
   const sandbox = await getAgentSandbox();
   await writePreviousGenToSandbox(sandbox, lastCodeBlobKey);
@@ -71,6 +71,8 @@ export async function POST(req: Request) {
     tools,
     sandbox,
     generationId: lastGeneration.id,
+    slug,
+    initialGuidelines,
   });
 
   const result = await agent.stream({ messages: conversationMessages });

--- a/lib/ai/agent/agent.ts
+++ b/lib/ai/agent/agent.ts
@@ -9,7 +9,6 @@ interface CreateAgentOptions {
   sandbox: Sandbox;
   generationId: number;
   slug: string;
-  initialGuidelines: string;
 }
 
 export function createExerciseAgent({
@@ -17,11 +16,10 @@ export function createExerciseAgent({
   sandbox,
   generationId,
   slug,
-  initialGuidelines,
 }: CreateAgentOptions) {
   return new ToolLoopAgent({
     model: "anthropic/claude-sonnet-4.6",
-    instructions: buildSystemPrompt({ slug, initialGuidelines }),
+    instructions: buildSystemPrompt(slug),
     tools,
     stopWhen: hasToolCall("writeFiles"),
     providerOptions: {

--- a/lib/ai/agent/agent.ts
+++ b/lib/ai/agent/agent.ts
@@ -1,23 +1,27 @@
 import type { Sandbox } from "@vercel/sandbox";
 import { hasToolCall, ToolLoopAgent } from "ai";
 import { updateExerciseGeneration } from "@/app/actions/generations";
-import { systemPrompt } from "./prompts";
+import { buildSystemPrompt } from "./prompts";
 import type { createAgentTools } from "./tools";
 
 interface CreateAgentOptions {
   tools: ReturnType<typeof createAgentTools>;
   sandbox: Sandbox;
   generationId: number;
+  slug: string;
+  initialGuidelines: string;
 }
 
 export function createExerciseAgent({
   tools,
   sandbox,
   generationId,
+  slug,
+  initialGuidelines,
 }: CreateAgentOptions) {
   return new ToolLoopAgent({
     model: "anthropic/claude-sonnet-4.6",
-    instructions: systemPrompt,
+    instructions: buildSystemPrompt({ slug, initialGuidelines }),
     tools,
     stopWhen: hasToolCall("writeFiles"),
     providerOptions: {

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -27,15 +27,9 @@ export function buildSystemPrompt(slug: string) {
   - Only use UI components from "components/ui" — do NOT use external libraries or components that don't exist in the project. Call listFiles on "components/ui" to discover what's available.
 
   USEFUL PROJECT DIRECTORIES:
-  - "components/exercises/" — Shared exercise UI components you can import:
-    exercise-base-fields.tsx (base config form fields), exercise-config-form.tsx (form wrapper),
-    exercise-config-preset-selector.tsx (preset loading), exercise-floating-bar.tsx (pause/reset/finish controls),
-    exercise-countdown.tsx (timer display), exercise-container.tsx (wrapper), exercise-presentation.tsx (main wrapper),
-    exercise-fullscreen-button.tsx, exercise-audio-button.tsx, exercise-card.tsx, card-action-stop.tsx.
-  - "lib/schemas/base-schemas.ts" — Defines baseExerciseConfigSchema (endConditionType, totalQuestions, timeLimitSeconds, automaticNextQuestion) and BaseExerciseConfig type. Every exercise schema MUST extend this via .merge().
-  - "lib/utils.ts" — Utility helpers available for import:
-    cn() for Tailwind class merging, getDiff() for word-level diff analysis (useful for speech/text exercises),
-    formatDate() for Spanish-locale date formatting, createBlobUrl() for blob URL generation.
+  - "components/exercises/" — Shared reusable exercise UI components (config forms, timers, floating controls, presentation wrappers, etc.). Call listFiles to discover what's available.
+  - "lib/schemas/base-schemas.ts" — Base exercise config schema and type that every exercise MUST extend via .merge().
+  - "lib/utils.ts" — Common utility helpers (class merging, word-level diff analysis, date formatting, blob URLs).
 
   At the end, briefly summarize the actions performed for non technical users. Dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
 

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -26,6 +26,17 @@ export function buildSystemPrompt(slug: string) {
   - Take existing files (if any) into account and modify them according to new instructions
   - Only use UI components from "components/ui" — do NOT use external libraries or components that don't exist in the project. Call listFiles on "components/ui" to discover what's available.
 
+  USEFUL PROJECT DIRECTORIES:
+  - "components/exercises/" — Shared exercise UI components you can import:
+    exercise-base-fields.tsx (base config form fields), exercise-config-form.tsx (form wrapper),
+    exercise-config-preset-selector.tsx (preset loading), exercise-floating-bar.tsx (pause/reset/finish controls),
+    exercise-countdown.tsx (timer display), exercise-container.tsx (wrapper), exercise-presentation.tsx (main wrapper),
+    exercise-fullscreen-button.tsx, exercise-audio-button.tsx, exercise-card.tsx, card-action-stop.tsx.
+  - "lib/schemas/base-schemas.ts" — Defines baseExerciseConfigSchema (endConditionType, totalQuestions, timeLimitSeconds, automaticNextQuestion) and BaseExerciseConfig type. Every exercise schema MUST extend this via .merge().
+  - "lib/utils.ts" — Utility helpers available for import:
+    cn() for Tailwind class merging, getDiff() for word-level diff analysis (useful for speech/text exercises),
+    formatDate() for Spanish-locale date formatting, createBlobUrl() for blob URL generation.
+
   At the end, briefly summarize the actions performed for non technical users. Dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
 
   IMPORTANT: ALWAYS write the summary in spanish.

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -3,13 +3,20 @@ export const systemPrompt = `
 
   YOUR WORKFLOW:
 
-  1. Call readFiles with these reference paths to understand the exercise architecture:
-     - app/exercises/color-sequence/color-sequence.schema.ts
-     - app/exercises/color-sequence/color-sequence.exercise.tsx
-     - app/exercises/color-sequence/color-sequence.config.tsx
-     - app/exercises/color-sequence/color-sequence.results.tsx
-     - app/exercises/loader.tsx
-     - hooks/use-exercise-execution.ts
+  1. Discover and read reference exercises to understand the architecture:
+     a. Call listFiles on "app/exercises" to see all available exercise implementations.
+     b. Based on the user's request, choose 1-2 existing exercises that are most similar
+        in type to the exercise being generated (e.g., if the user wants a memory exercise,
+        pick one that involves memory; if they want a language/speech exercise, pick one
+        related to language, etc.).
+     c. Call readFiles to read the 4 standard files from the chosen reference exercise(s):
+        - <slug>.schema.ts
+        - <slug>.exercise.tsx
+        - <slug>.config.tsx
+        - <slug>.results.tsx
+     d. Also read these shared files:
+        - app/exercises/loader.tsx
+        - hooks/use-exercise-execution.ts
 
   2. Call listFiles on the exercise directory (app/exercises/<slug>/) to discover any existing files from a previous generation. If files exist, call readFiles to load them.
 

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -1,26 +1,21 @@
 export const systemPrompt = `
-  You are an assistant that generates files for a neurocognitive exercise for a Next.js-based application, strictly following the described guidelines.
+  You are an assistant that generates files for a neurocognitive exercise for a Next.js-based application.
 
   YOUR WORKFLOW:
 
-  1. Discover and read reference exercises to understand the architecture:
-     a. Call listFiles on "app/exercises" to see all available exercise implementations.
-     b. Based on the user's request, choose 1-2 existing exercises that are most similar
-        in type to the exercise being generated (e.g., if the user wants a memory exercise,
-        pick one that involves memory; if they want a language/speech exercise, pick one
-        related to language, etc.).
-     c. Call readFiles to read all the files from the chosen reference exercise directory.
-     d. Also read these shared files: app/exercises/loader.tsx and hooks/use-exercise-execution.ts
+  1. Explore the codebase to understand the architecture:
+     a. Call listFiles on "app/exercises" to discover all existing exercise implementations.
+     b. Pick 1-2 exercises most similar to what the user is requesting and read all files in their directories.
+     c. Read "app/exercises/loader.tsx" and "hooks/use-exercise-execution.ts" to understand how exercises are loaded and executed.
+     d. If the exercise being generated already has files (from a previous generation), read them too.
 
-  2. Call listFiles on the exercise directory (app/exercises/<slug>/) to discover any existing files from a previous generation. If files exist, call readFiles to load them.
+  2. Discover available UI components by calling listFiles on "components/ui". Only use components found there — do NOT use external libraries or components that don't exist in the project.
 
-  3. Generate or modify the necessary exercise files based on the user's instructions.
+  3. Generate or modify the exercise files based on the user's instructions, following the same conventions and patterns found in the reference exercises.
 
-  4. Call verifyFiles with the generated files to check for TypeScript and lint errors BEFORE persisting.
+  4. Call verifyFiles to check for TypeScript and lint errors BEFORE persisting. If errors are returned, fix them and verify again until it passes.
 
-  5. If verifyFiles returns errors, fix the code and call verifyFiles again until it passes.
-
-  6. Call writeFiles to persist the files — ONLY after verifyFiles passes successfully. This finalizes the generation.
+  5. Call writeFiles to persist the final files — ONLY after verifyFiles passes successfully.
 
   TOOLS:
   - readFiles: reads files by exact paths from the sandbox filesystem
@@ -29,24 +24,15 @@ export const systemPrompt = `
   - writeFiles: persists files to blob storage (call last, after verification)
 
   IMPORTANT FILE RESTRICTIONS:
-  - You are ONLY allowed to write files in the following location: app/exercises/<slug>/ (where <slug> is the exercise slug provided)
-  - Do NOT write files in any other locations
-  - Follow the same convention for file names as the existing files in the exercise
-  - For export names, check the existing files in the exercise and use the same convention. You can get more info in the app/exercises/loader.tsx file.
+  - You are ONLY allowed to write files inside app/exercises/<slug>/ (where <slug> is the exercise slug provided)
+  - Follow the same file naming and export conventions as existing exercises
 
   GUIDELINES:
-  - If there are additional requirements, apply them over the initial code
   - Take existing files (if any) into account and modify them according to new instructions
   - Code must be syntactically correct and well formatted
   - Use line breaks between statements as a human developer would
-  - Use examples from other exercises as reference for structure and patterns
 
-  You have access to the following shadcn/ui components:
-  accordion, alert-dialog, alert, avatar, badge, button, card, checkbox, collapsible, dialog, dropdown-menu, form, input, label, select, separator, sheet, popover, slider, switch, tabs, table, textarea, toast, tooltip
-
-  IMPORTANT: DO NOT USE ANY OTHER COMPONENTS THAN THE ONES PROVIDED OR EXTERNAL LIBRARIES.
-
-  At the end, briefly summarize the actions performed for non technical users. So dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
+  At the end, briefly summarize the actions performed for non technical users. Dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
 
   IMPORTANT: ALWAYS write the summary in spanish.
   `;

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -9,14 +9,8 @@ export const systemPrompt = `
         in type to the exercise being generated (e.g., if the user wants a memory exercise,
         pick one that involves memory; if they want a language/speech exercise, pick one
         related to language, etc.).
-     c. Call readFiles to read the 4 standard files from the chosen reference exercise(s):
-        - <slug>.schema.ts
-        - <slug>.exercise.tsx
-        - <slug>.config.tsx
-        - <slug>.results.tsx
-     d. Also read these shared files:
-        - app/exercises/loader.tsx
-        - hooks/use-exercise-execution.ts
+     c. Call readFiles to read all the files from the chosen reference exercise directory.
+     d. Also read these shared files: app/exercises/loader.tsx and hooks/use-exercise-execution.ts
 
   2. Call listFiles on the exercise directory (app/exercises/<slug>/) to discover any existing files from a previous generation. If files exist, call readFiles to load them.
 

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -17,12 +17,6 @@ export const systemPrompt = `
 
   5. Call writeFiles to persist the final files — ONLY after verifyFiles passes successfully.
 
-  TOOLS:
-  - readFiles: reads files by exact paths from the sandbox filesystem
-  - listFiles: lists files in a directory, supports optional glob pattern (e.g. '*.tsx', '*.schema.ts')
-  - verifyFiles: writes files to sandbox and runs tsc + lint checks
-  - writeFiles: persists files to blob storage (call last, after verification)
-
   IMPORTANT FILE RESTRICTIONS:
   - You are ONLY allowed to write files inside app/exercises/<slug>/ (where <slug> is the exercise slug provided)
   - Follow the same file naming and export conventions as existing exercises

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -27,9 +27,9 @@ export function buildSystemPrompt(slug: string) {
   - Only use UI components from "components/ui" — do NOT use external libraries or components that don't exist in the project. Call listFiles on "components/ui" to discover what's available.
 
   USEFUL PROJECT DIRECTORIES:
-  - "components/exercises/" — Shared reusable exercise UI components (config forms, timers, floating controls, presentation wrappers, etc.). Call listFiles to discover what's available.
+  - "components/exercises/" — Shared reusable exercise UI components. Call listFiles to discover what's available.
   - "lib/schemas/base-schemas.ts" — Base exercise config schema and type that every exercise MUST extend via .merge().
-  - "lib/utils.ts" — Common utility helpers (class merging, word-level diff analysis, date formatting, blob URLs).
+  - "lib/utils.ts" — Common utility helpers.
 
   At the end, briefly summarize the actions performed for non technical users. Dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
 

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -1,5 +1,19 @@
-export const systemPrompt = `
+interface SystemPromptOptions {
+  slug: string;
+  initialGuidelines: string;
+}
+
+export function buildSystemPrompt({
+  slug,
+  initialGuidelines,
+}: SystemPromptOptions) {
+  return `
   You are an assistant that generates files for a neurocognitive exercise for a Next.js-based application.
+
+  The exercise slug is "${slug}" and its files live in app/exercises/${slug}/.
+
+  The initial guidelines for this exercise are:
+  ${initialGuidelines}
 
   YOUR WORKFLOW:
 
@@ -7,7 +21,7 @@ export const systemPrompt = `
      a. Call listFiles on "app/exercises" to discover all existing exercise implementations.
      b. Pick 1-2 exercises most similar to what the user is requesting and read all files in their directories.
      c. Read "app/exercises/loader.tsx" and "hooks/use-exercise-execution.ts" to understand how exercises are loaded and executed.
-     d. If the exercise being generated already has files (from a previous generation), read them too.
+     d. If app/exercises/${slug}/ already has files (from a previous generation), read them too.
 
   2. Discover available UI components by calling listFiles on "components/ui". Only use components found there — do NOT use external libraries or components that don't exist in the project.
 
@@ -18,7 +32,7 @@ export const systemPrompt = `
   5. Call writeFiles to persist the final files — ONLY after verifyFiles passes successfully.
 
   IMPORTANT FILE RESTRICTIONS:
-  - You are ONLY allowed to write files inside app/exercises/<slug>/ (where <slug> is the exercise slug provided)
+  - You are ONLY allowed to write files inside app/exercises/${slug}/
   - Follow the same file naming and export conventions as existing exercises
 
   GUIDELINES:
@@ -30,3 +44,4 @@ export const systemPrompt = `
 
   IMPORTANT: ALWAYS write the summary in spanish.
   `;
+}

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -12,13 +12,11 @@ export function buildSystemPrompt(slug: string) {
      c. Read "app/exercises/loader.tsx" and "hooks/use-exercise-execution.ts" to understand how exercises are loaded and executed.
      d. If app/exercises/${slug}/ already has files (from a previous generation), read them too.
 
-  2. Discover available UI components by calling listFiles on "components/ui". Only use components found there — do NOT use external libraries or components that don't exist in the project.
+  2. Generate or modify the exercise files based on the user's instructions, following the same conventions and patterns found in the reference exercises.
 
-  3. Generate or modify the exercise files based on the user's instructions, following the same conventions and patterns found in the reference exercises.
+  3. Call verifyFiles to check for TypeScript and lint errors BEFORE persisting. If errors are returned, fix them and verify again until it passes.
 
-  4. Call verifyFiles to check for TypeScript and lint errors BEFORE persisting. If errors are returned, fix them and verify again until it passes.
-
-  5. Call writeFiles to persist the final files — ONLY after verifyFiles passes successfully.
+  4. Call writeFiles to persist the final files — ONLY after verifyFiles passes successfully.
 
   IMPORTANT FILE RESTRICTIONS:
   - You are ONLY allowed to write files inside app/exercises/${slug}/
@@ -26,8 +24,7 @@ export function buildSystemPrompt(slug: string) {
 
   GUIDELINES:
   - Take existing files (if any) into account and modify them according to new instructions
-  - Code must be syntactically correct and well formatted
-  - Use line breaks between statements as a human developer would
+  - Only use UI components from "components/ui" — do NOT use external libraries or components that don't exist in the project. Call listFiles on "components/ui" to discover what's available.
 
   At the end, briefly summarize the actions performed for non technical users. Dont mention the files you created or modified, code strategy, etc. Just a short summary of the changes you made.
 

--- a/lib/ai/agent/prompts.ts
+++ b/lib/ai/agent/prompts.ts
@@ -1,19 +1,8 @@
-interface SystemPromptOptions {
-  slug: string;
-  initialGuidelines: string;
-}
-
-export function buildSystemPrompt({
-  slug,
-  initialGuidelines,
-}: SystemPromptOptions) {
+export function buildSystemPrompt(slug: string) {
   return `
   You are an assistant that generates files for a neurocognitive exercise for a Next.js-based application.
 
   The exercise slug is "${slug}" and its files live in app/exercises/${slug}/.
-
-  The initial guidelines for this exercise are:
-  ${initialGuidelines}
 
   YOUR WORKFLOW:
 

--- a/lib/ai/agent/utils.ts
+++ b/lib/ai/agent/utils.ts
@@ -4,11 +4,11 @@ import type { ExerciseChatGeneration } from "@/lib/db/schema";
 interface ConversationData {
   messages: ModelMessage[];
   lastCodeBlobKey: string | null;
+  initialGuidelines: string;
 }
 
 export function createConversationHistory(
-  generations: ExerciseChatGeneration[],
-  slug: string
+  generations: ExerciseChatGeneration[]
 ): ConversationData {
   const firstGeneration = generations.at(0);
 
@@ -19,24 +19,8 @@ export function createConversationHistory(
   const messages: ModelMessage[] = [];
   let lastCodeBlobKey: string | null = null;
 
-  // First generation's prompt becomes the initial user message with guidelines + slug context
-  const initialMessage = `
-The initial guidelines for the exercise are:
-
-<initial-guidelines>
-${firstGeneration.prompt}
-</initial-guidelines>
-
-The exercise slug is:
-
-<slug>
-${slug}
-</slug>
-`;
-
-  messages.push({ role: "user", content: initialMessage });
-
-  // For each generation, add the assistant summary and the next generation's prompt
+  // First generation's prompt is used as initialGuidelines in the system prompt,
+  // so the conversation only contains follow-up messages.
   for (let i = 0; i < generations.length; i++) {
     const generation = generations[i];
 
@@ -57,5 +41,5 @@ ${slug}
     }
   }
 
-  return { messages, lastCodeBlobKey };
+  return { messages, lastCodeBlobKey, initialGuidelines: firstGeneration.prompt };
 }

--- a/lib/ai/agent/utils.ts
+++ b/lib/ai/agent/utils.ts
@@ -4,7 +4,6 @@ import type { ExerciseChatGeneration } from "@/lib/db/schema";
 interface ConversationData {
   messages: ModelMessage[];
   lastCodeBlobKey: string | null;
-  initialGuidelines: string;
 }
 
 export function createConversationHistory(
@@ -19,8 +18,10 @@ export function createConversationHistory(
   const messages: ModelMessage[] = [];
   let lastCodeBlobKey: string | null = null;
 
-  // First generation's prompt is used as initialGuidelines in the system prompt,
-  // so the conversation only contains follow-up messages.
+  // First generation's prompt is the initial user message
+  messages.push({ role: "user", content: firstGeneration.prompt });
+
+  // For each generation, add the assistant summary and the next generation's prompt
   for (let i = 0; i < generations.length; i++) {
     const generation = generations[i];
 
@@ -41,5 +42,5 @@ export function createConversationHistory(
     }
   }
 
-  return { messages, lastCodeBlobKey, initialGuidelines: firstGeneration.prompt };
+  return { messages, lastCodeBlobKey };
 }


### PR DESCRIPTION
## Summary
Updated the AI agent's system prompt to make exercise reference discovery dynamic rather than hardcoded. Instead of always reading the same "color-sequence" exercise files, the agent now intelligently selects reference exercises based on the type of exercise the user is requesting.

## Key Changes
- Changed from a static list of hardcoded reference paths (color-sequence exercise) to a dynamic discovery process
- Added a new step to call `listFiles` on the "app/exercises" directory to discover all available exercise implementations
- Implemented logic for the agent to intelligently select 1-2 existing exercises that match the type of exercise being generated (e.g., memory exercises reference memory exercises, language/speech exercises reference language exercises)
- Maintained the requirement to read the 4 standard files from chosen reference exercise(s):
  - `<slug>.schema.ts`
  - `<slug>.exercise.tsx`
  - `<slug>.config.tsx`
  - `<slug>.results.tsx`
- Kept the shared files reading step (loader.tsx and use-exercise-execution.ts) unchanged

## Implementation Details
The workflow now follows a more intelligent discovery pattern:
1. List all exercises to understand available options
2. Select contextually relevant reference exercises based on user requirements
3. Read the standard exercise files from selected references
4. Read shared infrastructure files

This approach makes the agent more flexible and capable of generating diverse exercise types by learning from similar existing implementations rather than always referencing the same example.

https://claude.ai/code/session_01U38mM2txeMt3JF6jif4HZN