### PR TITLE
Add fork support for exercise chat generations

### DIFF
--- a/app/actions/generations.ts
+++ b/app/actions/generations.ts
@@ -26,6 +26,7 @@ export async function createExerciseGeneration(data: {
   exerciseId: number;
   prompt: string;
   status?: "PENDING" | "GENERATING" | "COMPLETED" | "ERROR";
+  forkedFromId?: number;
 }): Promise<ExerciseChatGeneration | null> {
   try {
     const user = await getCurrentUser();
@@ -41,6 +42,7 @@ export async function createExerciseGeneration(data: {
         userId: user.id,
         status: data.status || "PENDING",
         prompt: data.prompt,
+        forkedFromId: data.forkedFromId ?? null,
       })
       .returning();
 

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -12,7 +12,7 @@ import {
 import { createConversationHistory } from "@/lib/ai/agent/utils";
 
 export async function POST(req: Request) {
-  const { messages, slug } = await req.json();
+  const { messages, slug, forkedFromId } = await req.json();
 
   const lastMessage = messages.at(-1);
 
@@ -45,6 +45,7 @@ export async function POST(req: Request) {
       exerciseId: exercise.id,
       prompt: lastMessageContent,
       status: "GENERATING",
+      forkedFromId: forkedFromId ?? undefined,
     });
 
     if (!newGeneration) {
@@ -60,8 +61,9 @@ export async function POST(req: Request) {
     return new Response("Failed to create generation", { status: 500 });
   }
 
+  const effectiveForkBaseId = lastGeneration?.forkedFromId ?? undefined;
   const { messages: conversationMessages, lastCodeBlobKey } =
-    createConversationHistory(generations, slug);
+    createConversationHistory(generations, slug, effectiveForkBaseId);
 
   const sandbox = await getAgentSandbox();
   await writePreviousGenToSandbox(sandbox, lastCodeBlobKey);

--- a/app/dashboard/exercises/[slug]/chat.tsx
+++ b/app/dashboard/exercises/[slug]/chat.tsx
@@ -7,11 +7,14 @@ import {
   CheckCircle,
   Code,
   FolderSearch,
+  GitFork,
   Loader2,
   MessageSquare,
   Settings,
+  X,
 } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { parseAsInteger, useQueryState } from "nuqs";
+import { useEffect, useMemo, useRef } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -32,7 +35,7 @@ import {
   PromptInputTextarea,
 } from "@/components/ai-elements/prompt-input";
 import { useSandbox } from "@/hooks/use-sandbox";
-import type { Exercise } from "@/lib/db/schema";
+import type { Exercise, ExerciseChatGeneration } from "@/lib/db/schema";
 
 interface InitialMessage {
   id: string;
@@ -45,6 +48,7 @@ interface ChatProps {
   messages: InitialMessage[];
   exercise: Exercise;
   autoStart: boolean;
+  generations: ExerciseChatGeneration[];
 }
 
 function getToolIcon(toolName: string) {
@@ -142,16 +146,36 @@ export function Chat({
   messages: initialMessages,
   exercise,
   autoStart,
+  generations,
 }: ChatProps) {
   const { initializePreview } = useSandbox();
   const hasAutoStarted = useRef(false);
+  const [gen, setGen] = useQueryState("gen", parseAsInteger);
+
+  const completedGenerations = generations.filter(
+    (g) => g.status === "COMPLETED"
+  );
+  const latestCompletedId = completedGenerations.at(-1)?.id;
+  const forkedFromId =
+    gen && gen !== latestCompletedId ? gen : undefined;
+
+  // Compute the version number for the fork banner
+  const forkVersionNumber = forkedFromId
+    ? completedGenerations.findIndex((g) => g.id === forkedFromId) + 1
+    : null;
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/chat",
+        credentials: "include",
+        body: { slug: exercise.slug, forkedFromId },
+      }),
+    [exercise.slug, forkedFromId]
+  );
 
   const { messages, sendMessage, status, error, stop, regenerate } = useChat({
-    transport: new DefaultChatTransport({
-      api: "/api/chat",
-      credentials: "include",
-      body: { slug: exercise.slug },
-    }),
+    transport,
     messages: initialMessages.map((msg) => ({
       id: msg.id,
       role: msg.role,
@@ -227,6 +251,20 @@ export function Chat({
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>
+
+      {forkedFromId && forkVersionNumber && (
+        <div className="flex shrink-0 items-center gap-2 border-t bg-amber-50 px-3 py-2 text-amber-700 text-xs">
+          <GitFork className="h-3.5 w-3.5 shrink-0" />
+          <span>Continuando desde versi&oacute;n {forkVersionNumber}</span>
+          <button
+            className="ml-auto text-amber-600 underline hover:text-amber-800"
+            onClick={() => setGen(null)}
+            type="button"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
 
       <div className="shrink-0 border-t p-2">
         <PromptInput onSubmit={handleSubmit}>

--- a/app/dashboard/exercises/[slug]/generation-history.tsx
+++ b/app/dashboard/exercises/[slug]/generation-history.tsx
@@ -2,7 +2,7 @@
 
 import { formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
-import { Check, History } from "lucide-react";
+import { Check, GitFork, History } from "lucide-react";
 import { parseAsInteger, useQueryState } from "nuqs";
 import { Button } from "@/components/ui/button";
 import {
@@ -73,6 +73,9 @@ export function GenerationHistory({ generations }: GenerationHistoryProps) {
                     <span className="font-medium text-xs">
                       v{versionNumber}
                     </span>
+                    {generation.forkedFromId && (
+                      <GitFork className="h-3 w-3 text-amber-500" />
+                    )}
                     <span className="text-gray-400 text-xs">
                       {formatDistanceToNow(generation.createdAt, {
                         addSuffix: true,

--- a/app/dashboard/exercises/[slug]/page.tsx
+++ b/app/dashboard/exercises/[slug]/page.tsx
@@ -74,6 +74,7 @@ export default async function ExerciseChatPage({ params }: PageProps) {
                 <Chat
                   autoStart={autoStart}
                   exercise={exercise}
+                  generations={generations}
                   messages={messages}
                 />
               </div>

--- a/lib/ai/agent/utils.ts
+++ b/lib/ai/agent/utils.ts
@@ -6,15 +6,56 @@ interface ConversationData {
   lastCodeBlobKey: string | null;
 }
 
+/**
+ * Builds the ancestor chain for a given generation by following forkedFromId links.
+ * For linear (non-forked) generations, walks backward through chronological order.
+ */
+function buildAncestorChain(
+  generations: ExerciseChatGeneration[],
+  targetId: number
+): ExerciseChatGeneration[] {
+  const byId = new Map(generations.map((g) => [g.id, g]));
+  const indexById = new Map(generations.map((g, i) => [g.id, i]));
+
+  const chain: ExerciseChatGeneration[] = [];
+  let currentId: number | null = targetId;
+
+  while (currentId !== null) {
+    const gen = byId.get(currentId);
+    if (!gen) break;
+    chain.unshift(gen);
+
+    if (gen.forkedFromId) {
+      // Follow the explicit fork link
+      currentId = gen.forkedFromId;
+    } else {
+      // Linear parent: include all chronological predecessors
+      const idx = indexById.get(gen.id);
+      if (idx !== undefined && idx > 0) {
+        chain.unshift(...generations.slice(0, idx));
+      }
+      break;
+    }
+  }
+
+  return chain;
+}
+
 export function createConversationHistory(
   generations: ExerciseChatGeneration[],
-  slug: string
+  slug: string,
+  forkBaseId?: number
 ): ConversationData {
   const firstGeneration = generations.at(0);
 
   if (!firstGeneration) {
     throw new Error("No generations available");
   }
+
+  // When forking, use only the ancestor chain up to the fork base
+  const effectiveGenerations = forkBaseId
+    ? buildAncestorChain(generations, forkBaseId)
+    : generations;
 
   const messages: ModelMessage[] = [];
   let lastCodeBlobKey: string | null = null;
@@ -24,7 +65,7 @@ export function createConversationHistory(
 The initial guidelines for the exercise are:
 
 <initial-guidelines>
-${firstGeneration.prompt}
+${effectiveGenerations[0].prompt}
 </initial-guidelines>
 
 The exercise slug is:
@@ -37,11 +78,11 @@ ${slug}
   messages.push({ role: "user", content: initialMessage });
 
   // For each generation, add the assistant summary and the next generation's prompt
-  for (let i = 0; i < generations.length; i++) {
-    const generation = generations[i];
+  for (let i = 0; i < effectiveGenerations.length; i++) {
+    const generation = effectiveGenerations[i];
 
     // Track the most recent codeBlobKey before the current (last) generation
-    if (i < generations.length - 1 && generation.codeBlobKey) {
+    if (i < effectiveGenerations.length - 1 && generation.codeBlobKey) {
       lastCodeBlobKey = generation.codeBlobKey;
     }
 
@@ -50,10 +91,18 @@ ${slug}
     }
 
     // Add the next generation's prompt as a user message
-    const nextGeneration = generations[i + 1];
+    const nextGeneration = effectiveGenerations[i + 1];
 
     if (nextGeneration) {
       messages.push({ role: "user", content: nextGeneration.prompt });
+    }
+  }
+
+  // For forks, ensure the lastCodeBlobKey is the fork base's codeBlobKey
+  if (forkBaseId) {
+    const forkBase = effectiveGenerations.find((g) => g.id === forkBaseId);
+    if (forkBase?.codeBlobKey) {
+      lastCodeBlobKey = forkBase.codeBlobKey;
     }
   }
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -376,6 +376,7 @@ export const exerciseChatGeneration = pgTable(
     sandboxId: varchar("sandbox_id", { length: 255 }),
     summary: text("summary"),
     prompt: text("prompt").notNull(),
+    forkedFromId: integer("forked_from_id"),
     ...timestamps,
   },
   (table) => [
@@ -393,6 +394,11 @@ export const exerciseChatGeneration = pgTable(
       foreignColumns: [users.id],
       name: "exercise_chat_generation_user_fk",
     }).onDelete("cascade"),
+    foreignKey({
+      columns: [table.forkedFromId],
+      foreignColumns: [table.id],
+      name: "exercise_chat_generation_forked_from_fk",
+    }).onDelete("set null"),
   ]
 );
 
@@ -658,6 +664,11 @@ export const exerciseChatGenerationRelations = relations(
     user: one(users, {
       fields: [exerciseChatGeneration.userId],
       references: [users.id],
+    }),
+    forkedFrom: one(exerciseChatGeneration, {
+      fields: [exerciseChatGeneration.forkedFromId],
+      references: [exerciseChatGeneration.id],
+      relationName: "forkedGeneration",
     }),
   })
 );


### PR DESCRIPTION
## Summary
This PR adds the ability to fork exercise chat conversations from any previous generation, allowing users to explore alternative solution paths while maintaining the conversation history up to the fork point.

## Key Changes

- **Database Schema**: Added `forkedFromId` field to `exerciseChatGeneration` table with a self-referential foreign key to track fork origins
- **Ancestor Chain Logic**: Implemented `buildAncestorChain()` function to reconstruct conversation history for forked generations, following explicit fork links and including chronological predecessors for linear conversations
- **Conversation History**: Updated `createConversationHistory()` to accept an optional `forkBaseId` parameter and use only the ancestor chain up to the fork point when provided
- **Chat UI**: 
  - Added query parameter support (`gen`) to track which generation a fork originates from
  - Displays a banner indicating the fork source version with option to clear the fork state
  - Passes `forkedFromId` to the chat API transport
- **API Endpoint**: Modified `/api/chat` route to accept and propagate `forkedFromId` when creating new generations
- **Generation History**: Added visual indicator (GitFork icon) to show which generations are forks
- **Server Actions**: Updated `createExerciseGeneration()` to accept and store `forkedFromId`

## Implementation Details

- Fork detection uses the `gen` query parameter to identify the fork base generation
- When a fork is active, the conversation history is reconstructed to include only ancestors up to the fork point, ensuring the AI model has the correct context
- The fork base's code blob is explicitly set as the `lastCodeBlobKey` to ensure the sandbox starts from the correct state
- Visual feedback includes a dismissible banner showing "Continuando desde versión X" (Continuing from version X)

https://claude.ai/code/session_01HgSgZqvTRxg8GTA3awBDtx